### PR TITLE
More cleanup and refactoring

### DIFF
--- a/StatsDownload/StatsDownload.Core/Extensions/AssemblyExtensions.cs
+++ b/StatsDownload/StatsDownload.Core/Extensions/AssemblyExtensions.cs
@@ -1,0 +1,22 @@
+﻿namespace StatsDownload.Core.Extensions
+{
+    using System;
+    using System.IO;
+    using System.Reflection;
+
+    public static class AssemblyExtensions
+    {
+        public static string GetCodebaseDirectory(this Assembly assembly)
+        {
+            string path = GetCodebaseFilename(assembly);
+            return Path.GetDirectoryName(path);
+        }
+
+        public static string GetCodebaseFilename(this Assembly assembly)
+        {
+            string codeBase = assembly.CodeBase;
+            var uri = new UriBuilder(codeBase);
+            return Uri.UnescapeDataString(uri.Path);
+        }
+    }
+}

--- a/StatsDownload/StatsDownload.Core/StatsDownload.Core.csproj
+++ b/StatsDownload/StatsDownload.Core/StatsDownload.Core.csproj
@@ -56,6 +56,7 @@
     <Compile Include="Exceptions\FileDownloadArgumentException.cs" />
     <Compile Include="Exceptions\FileDownloadFailedDecompressionException.cs" />
     <Compile Include="Exceptions\InvalidStatsFileException.cs" />
+    <Compile Include="Extensions\AssemblyExtensions.cs" />
     <Compile Include="Implementations\Tested\AdditionalUserDataParserProvider.cs" />
     <Compile Include="Implementations\Tested\BitcoinAddressValidatorProvider.cs" />
     <Compile Include="Implementations\Tested\StatsDownloadEmailProvider.cs" />
@@ -125,6 +126,7 @@
       <Name>StatsDownload.Logging</Name>
     </ProjectReference>
   </ItemGroup>
+  <ItemGroup />
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DependencyRegistration.cs
+++ b/StatsDownload/StatsDownload.FileDownload.Console/CastleWindsor/DependencyRegistration.cs
@@ -1,24 +1,15 @@
 ﻿namespace StatsDownload.FileDownload.Console
 {
-    using System;
-    using System.IO;
     using System.Reflection;
 
     using Castle.MicroKernel.Registration;
     using Castle.Windsor.Installer;
 
+    using StatsDownload.Core.Extensions;
+
     internal static class DependencyRegistration
     {
-        private static string AssemblyDirectory
-        {
-            get
-            {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                var uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
-            }
-        }
+        private static string AssemblyDirectory => Assembly.GetExecutingAssembly().GetCodebaseDirectory();
 
         internal static void Register()
         {

--- a/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/DependencyRegistration.cs
+++ b/StatsDownload/StatsDownload.FileServer.TestHarness/CastleWindsor/DependencyRegistration.cs
@@ -1,24 +1,14 @@
 ﻿namespace StatsDownload.FileServer.TestHarness
 {
-    using System;
-    using System.IO;
     using System.Reflection;
 
     using Castle.MicroKernel.Registration;
     using Castle.Windsor.Installer;
+    using StatsDownload.Core.Extensions;
 
     internal static class DependencyRegistration
     {
-        private static string AssemblyDirectory
-        {
-            get
-            {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                var uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
-            }
-        }
+        private static string AssemblyDirectory => Assembly.GetExecutingAssembly().GetCodebaseDirectory();
 
         internal static void Register()
         {

--- a/StatsDownload/StatsDownload.FileServer.TestHarness/StatsDownload.FileServer.TestHarness.csproj
+++ b/StatsDownload/StatsDownload.FileServer.TestHarness/StatsDownload.FileServer.TestHarness.csproj
@@ -90,6 +90,12 @@
   <ItemGroup>
     <Content Include="InstallingCertificateForSelfHostedService.txt" />
   </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\StatsDownload.Core\StatsDownload.Core.csproj">
+      <Project>{E7A915E2-603D-419F-8987-170CE7814ED4}</Project>
+      <Name>StatsDownload.Core</Name>
+    </ProjectReference>
+  </ItemGroup>
   <Import Project="$(MSBuildToolsPath)\Microsoft.CSharp.targets" />
   <!-- To modify your build process, add your task inside one of the targets below and uncomment it. 
        Other similar extension points exist, see Microsoft.Common.targets.

--- a/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DependencyRegistration.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/CastleWindsor/DependencyRegistration.cs
@@ -1,24 +1,15 @@
 ﻿namespace StatsDownload.StatsUpload.Console
 {
-    using System;
-    using System.IO;
     using System.Reflection;
 
     using Castle.MicroKernel.Registration;
     using Castle.Windsor.Installer;
 
+    using StatsDownload.Core.Extensions;
+
     internal static class DependencyRegistration
     {
-        private static string AssemblyDirectory
-        {
-            get
-            {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                var uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
-            }
-        }
+        private static string AssemblyDirectory => Assembly.GetExecutingAssembly().GetCodebaseDirectory();
 
         internal static void Register()
         {

--- a/StatsDownload/StatsDownload.StatsUpload.Console/StatsUploadConsoleSettingsProvider.cs
+++ b/StatsDownload/StatsDownload.StatsUpload.Console/StatsUploadConsoleSettingsProvider.cs
@@ -1,8 +1,7 @@
 ﻿namespace StatsDownload.StatsUpload.Console
 {
+    using System;
     using System.Configuration;
-    using System.IO;
-    using System.Reflection;
 
     using StatsDownload.Core;
     using StatsDownload.Email;
@@ -23,7 +22,7 @@
         public string GetDownloadDirectory()
         {
             return ConfigurationManager.AppSettings["DownloadDirectory"]
-                   ?? Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
+                   ?? Environment.GetFolderPath(Environment.SpecialFolder.DesktopDirectory, Environment.SpecialFolderOption.Create);
         }
 
         public string GetDownloadTimeout()

--- a/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyRegistration.cs
+++ b/StatsDownload/StatsDownload.TestHarness/CastleWindsor/DependencyRegistration.cs
@@ -1,24 +1,15 @@
 ﻿namespace StatsDownload.TestHarness
 {
-    using System;
-    using System.IO;
     using System.Reflection;
 
     using Castle.MicroKernel.Registration;
     using Castle.Windsor.Installer;
 
+    using StatsDownload.Core.Extensions;
+
     internal static class DependencyRegistration
     {
-        private static string AssemblyDirectory
-        {
-            get
-            {
-                string codeBase = Assembly.GetExecutingAssembly().CodeBase;
-                var uri = new UriBuilder(codeBase);
-                string path = Uri.UnescapeDataString(uri.Path);
-                return Path.GetDirectoryName(path);
-            }
-        }
+        private static string AssemblyDirectory => Assembly.GetExecutingAssembly().GetCodebaseDirectory();
 
         internal static void Register()
         {

--- a/StatsDownload/StatsDownload.TestHarness/MainForm.cs
+++ b/StatsDownload/StatsDownload.TestHarness/MainForm.cs
@@ -13,7 +13,7 @@
         public MainForm()
         {
             InitializeComponent();
-            WindsorContainer.Instance.Register(Component.For<MainForm>().Instance(this));
+            WindsorContainer.Instance.Register(Component.For<Action<string>>().Instance(Log));
         }
 
         internal void Log(string message)

--- a/StatsDownload/StatsDownload.TestHarness/TestHarnessLoggingProvider.cs
+++ b/StatsDownload/StatsDownload.TestHarness/TestHarnessLoggingProvider.cs
@@ -6,21 +6,21 @@
 
     public class TestHarnessLoggingProvider : IApplicationLoggingService
     {
-        public TestHarnessLoggingProvider(MainForm mainForm)
-        {
-            Log = mainForm.Log;
-        }
+        private readonly Action<string> logAction;
 
-        private Action<string> Log { get; }
+        public TestHarnessLoggingProvider(Action<string> logAction)
+        {
+            this.logAction = logAction;
+        }
 
         public void LogError(string message)
         {
-            Log?.Invoke(message);
+            logAction?.Invoke(message);
         }
 
         public void LogVerbose(string message)
         {
-            Log?.Invoke(message);
+            logAction?.Invoke(message);
         }
     }
 }


### PR DESCRIPTION
*  Remove dependency on MainForm from TestHarnessLoggingProvider
* Refactor to remove duplicated logic for getting real assembly path.
* Use desktop as default download folder